### PR TITLE
# This is a combination of 2 commits.

### DIFF
--- a/defaults-fairship-2018.sh
+++ b/defaults-fairship-2018.sh
@@ -11,6 +11,8 @@ disable:
   - ApMon-CPP
   - DDS
 overrides:
+  FairShip:
+    tag: "SHiP-2018"
   autotools:
     tag: v1.5.0
   boost:
@@ -31,8 +33,9 @@ overrides:
   XRootD:
     tag: v4.8.3
   ROOT:
-    tag: "v6-18-00"
-    source: https://github.com/root-project/root
+    version: "%(tag_basename)s"
+    tag: "v6-14-00-ship"
+    source: https://github.com/ShipSoft/root
     requires:
       - GSL
       - opengl:(?!osx)
@@ -51,6 +54,7 @@ overrides:
       - "Xcode:(osx.*)"
       - libxml2
     prefer_system_check: |
+      ls $ROOT_ROOT/aclocal > /dev/null && \
       ls $ROOT_ROOT/bin > /dev/null && \
       ls $ROOT_ROOT/cmake > /dev/null && \
       ls $ROOT_ROOT/config > /dev/null && \
@@ -63,6 +67,7 @@ overrides:
       ls $ROOT_ROOT/lib > /dev/null && \
       ls $ROOT_ROOT/macros > /dev/null && \
       ls $ROOT_ROOT/man > /dev/null && \
+      ls $ROOT_ROOT/tmva > /dev/null && \
       true
   GSL:
     version: "v1.16%(defaults_upper)s"
@@ -302,8 +307,8 @@ overrides:
       ls $XERCESC_ROOT/lib/libxerces-c.so > /dev/null
   GEANT3:
     version: "%(tag_basename)s"
-    source: https://github.com/vmc-project/geant3
-    tag: v2-7
+    source: https://github.com/ShipSoft/geant3
+    tag: v3.2.1-ship-patch-TVMC
     prefer_system_check: |
       ls $GEANT3_ROOT/ > /dev/null && \
       ls $GEANT3_ROOT/include > /dev/null && \

--- a/fairship.sh
+++ b/fairship.sh
@@ -11,7 +11,6 @@ requires:
   - PHOTOSPP
   - EvtGen
   - ROOT
-  - madgraph5
 build_requires:
   - googletest
 incremental_recipe: |
@@ -105,6 +104,8 @@ cmake $SOURCEDIR                                                 \
       -DEVTGENPATH=$EVTGEN_ROOT                                  \
       -DEVTGEN_INCLUDE_DIR=$EVTGEN_ROOT/include                  \
       -DEVTGEN_LIBRARY_DIR=$EVTGEN_ROOT/lib                      \
+      ${PYTHON_ROOT:+-DPYTHON_LIBRARY=$PYTHON_ROOT/lib}          \
+      ${PYTHON_ROOT:+-DPYTHON_INCLUDE_DIR=$PYTHON_ROOT/include/python2.7} \
       -DPythia6_LIBRARY_DIR=$PYTHIA6_ROOT/lib                    \
       -DPYTHIA8_DIR=$PYTHIA_ROOT                                 \
       -DPYTHIA8_INCLUDE_DIR=$PYTHIA_ROOT/include                 \
@@ -154,7 +155,7 @@ module load BASE/1.0                                                            
             ${GENIE_VERSION:+GENIE/$GENIE_VERSION-$GENIE_REVISION}              \\
             ${PHOTOSPP_VERSION:+PHOTOSPP/$PHOTOSPP_VERSION-$PHOTOSPP_REVISION}  \\
             ${EVTGEN_VERSION:+EvtGen/$EVTGEN_VERSION-$EVTGEN_REVISION}          \\
-            FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION                       \\
+            ${FAIRROOT_VERSION:+FairRoot/$FAIRROOT_VERSION-$FAIRROOT_REVISION}	\\
             ${MADGRAPH5_VERSION:+madgraph5/$MADGRAPH5_VERSION-$MADGRAPH5_REVISION}
 # Our environment
 setenv EOSSHIP root://eospublic.cern.ch/
@@ -178,5 +179,3 @@ prepend-path PYTHONPATH \$::env(FAIRSHIP_ROOT)/python
 append-path PYTHONPATH \$::env(FAIRSHIP_ROOT)/Developments/track_pattern_recognition
 $([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(FAIRSHIP_ROOT)/lib")
 EoF
-
-

--- a/go.sh
+++ b/go.sh
@@ -2,6 +2,10 @@ package: go
 version: v1.7.3
 source: https://github.com/golang/go
 tag: go1.7.3
+prefer_system: .*
+prefer_system_check: |
+    go list -f '{{context.ReleaseTags}}' runtime | grep go1.7;
+     if [ $? -ne 0 ]; then printf "go not found, install go >= 1.7 to avoid recompile it"; exit 1; fi
 ---
 #!/bin/sh
 

--- a/lhapdf5.sh
+++ b/lhapdf5.sh
@@ -1,9 +1,10 @@
 package: lhapdf5
-tag: alice/v5.9.1
-version: "%(tag_basename)s%(defaults_upper)s"
-source: https://github.com/alisw/LHAPDF
+tag: v5.9.1-ship2
+version: "%(tag_basename)s"
+source: https://github.com/ShipSoft/LHAPDF.git
 env:
-  LHAPATH: "$LHAPDF5_ROOT/share/lhapdf"
+  LHAPATH: "$LHAPDF_ROOT/share/LHAPDF"
+  GEANT4_INSTALL: "$GEANT4_ROOT"
 requires:
  - "GCC-Toolchain:(?!osx)"
 ---
@@ -20,7 +21,7 @@ make install
 
 PDFSETS="cteq6l cteq6ll CT10 CT10nlo MSTW2008nnlo EPS09LOR_208 EPS09NLOR_208 cteq66a cteq66a0 cteq4m"
 pushd $INSTALLROOT/share/lhapdf
-  $INSTALLROOT/bin/lhapdf-getdata $PDFSETS
+  $INSTALLROOT/bin/lhapdf-getdata --repo=https://www.hepforge.org/archive/lhapdf/pdfsets/5.9.1 $PDFSETS
   # Check if PDF sets were really installed
   for P in $PDFSETS; do
     ls ${P}*

--- a/libxml2.sh
+++ b/libxml2.sh
@@ -1,11 +1,11 @@
 package: libxml2
-version: v2.9.3
-source: https://git.gnome.org/browse/libxml2
+version: "%(tag_basename)s"
 tag: v2.9.3
 build_requires:
   - autotools
   - zlib
   - "GCC-Toolchain:(?!osx)"
+source: https://gitlab.gnome.org/GNOME/libxml2.git
 prefer_system: "(?!slc5)"
 prefer_system_check: |
   xml2-config --version;
@@ -33,7 +33,7 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0
+module load BASE/1.0 ${ZLIB_VERSION:+zlib/$ZLIB_VERSION-$ZLIB_REVISION}
 # Our environment
 setenv LIBXML2_VERSION \$version
 setenv LIBXML2_ROOT \$::env(BASEDIR)/$PKGNAME/\$::env(LIBXML2_VERSION)

--- a/openssl.sh
+++ b/openssl.sh
@@ -1,10 +1,10 @@
 package: OpenSSL
-version: v0.9.8zf
-tag: "v0.9.8_1.2.4"
-source: https://github.com/alisw/alice-openssl.git
+version: v1.0.2o
+tag: OpenSSL_1_0_2o
+source: https://github.com/openssl/openssl
 prefer_system: (?!slc5|slc6)
 prefer_system_check: |
-  if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi; echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1
+  if [ `uname` = Darwin ]; then test -d `brew --prefix openssl || echo /dev/nope` || exit 1; fi; echo '#include <openssl/bio.h>' | c++ -x c++ - -I`brew --prefix openssl`/include -c -o /dev/null || exit 1; echo -e "#include <openssl/opensslv.h>\n#if OPENSSL_VERSION_NUMBER >= 0x10100000L\n#error \"System's GCC cannot be used: we need OpenSSL 1.0.x to build XrootD. We are going to compile our own version.\"\n#endif\nint main() { }" | cc -xc++ - -c -o /dev/null || exit 1
 build_requires:
  - zlib
  - "GCC-Toolchain:(?!osx)"
@@ -13,47 +13,47 @@ build_requires:
 
 rsync -av --delete --exclude="**/.git" $SOURCEDIR/ .
 
-pushd openssl-fips
-  ./config --openssldir=$INSTALLROOT/fips \
-           fipscanisterbuild \
-           no-asm
-  # Does not build in multicore!
-  make
-  make install
-popd
+./config --prefix="$INSTALLROOT"                   \
+         --openssldir="$INSTALLROOT/etc/ssl"       \
+         --libdir=lib                              \
+         zlib                                      \
+         no-idea                                   \
+         no-mdc2                                   \
+         no-rc5                                    \
+         no-ec                                     \
+         no-ecdh                                   \
+         no-ecdsa                                  \
+         no-asm                                    \
+         no-krb5                                   \
+         shared                                    \
+         -fno-strict-aliasing                      \
+         -L"$INSTALLROOT/lib"                      \
+         -Wa,--noexecstack
+make depend
+make  # don't ever try to build in multicore
+make install
 
-OLD_OPENSSL=TRUE
-if [ "$PKG_VERSION" == "*v1.0*" ]
-then
-    unset OLD_OPENSSL
-    NEW_OPENSSL=TRUE
-fi
+# Remove static libraries and pkgconfig
+rm -rf $INSTALLROOT/lib/pkgconfig \
+       $INSTALLROOT/lib/*.a
 
-pushd openssl
-  ./config --openssldir="$INSTALLROOT" \
-           ${OLD_OPENSSL:+--with-fipslibdir="$INSTALLROOT/fips/lib"}  \
-           ${NEW_OPENSSL:+--with-fipslibdir="$INSTALLROOT/fips/lib/"} \
-           ${NEW_OPENSSL:+--with-fipsdir="$INSTALLROOT/fips"} \
-           fips \
-           zlib \
-           no-idea \
-           no-mdc2 \
-	   ${OLD_OPENSSL:+ no-ec no-ecdh no-ecdsa} \
-           no-rc5 \
-           no-asm \
-           no-krb5 \
-           shared \
-           -fno-strict-aliasing \
-           -L"${INSTALLROOT}/lib" \
-           -Wa,--noexecstack \
-           -DOPENSSL_USE_NEW_FUNCTIONS
-  # Does not build in multicore!
-  ${NEW_OPENSSL:+ make depend}
-  make
-  make install
-popd
-
-rm -rf $INSTALLROOT/pkgconfig \
-       $INSTALLROOT/fips/pkgconfig \
-       $INSTALLROOT/lib/*.a \
-       $INSTALLROOT/fips/lib/*.a
+# Modulefile
+MODULEDIR="$INSTALLROOT/etc/modulefiles"
+MODULEFILE="$MODULEDIR/$PKGNAME"
+mkdir -p "$MODULEDIR"
+cat > "$MODULEFILE" <<EoF
+#%Module1.0
+proc ModulesHelp { } {
+  global version
+  puts stderr "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+}
+set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
+module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
+# Dependencies
+module load BASE/1.0 ${ZLIB_VERSION:+zlib/$ZLIB_VERSION-$ZLIB_REVISION} ${GCC_TOOLCHAIN_ROOT:+GCC-Toolchain/$GCC_TOOLCHAIN_VERSION-$GCC_TOOLCHAIN_REVISION}
+# Our environment
+setenv OPENSSL_ROOT \$::env(BASEDIR)/$PKGNAME/\$version
+prepend-path PATH \$::env(OPENSSL_ROOT)/bin
+prepend-path LD_LIBRARY_PATH \$::env(OPENSSL_ROOT)/lib
+$([[ ${ARCHITECTURE:0:3} == osx ]] && echo "prepend-path DYLD_LIBRARY_PATH \$::env(OPENSSL_ROOT)/lib")
+EoF

--- a/python.sh
+++ b/python.sh
@@ -7,60 +7,77 @@ requires:
  - FreeType
  - libpng
  - sqlite
+ - OpenSSL
 build_requires:
  - curl
 env:
-  SSL_CERT_FILE: "$(export PATH=$PYTHON_ROOT/bin:$PATH; export LD_LIBRARY_PATH=$PYTHON_ROOT/lib:$LD_LIBRARY_PATH; python -c \"import certifi; print certifi.where()\")"
   PYTHONHOME: "$PYTHON_ROOT"
 prefer_system: (?!slc5)
 prefer_system_check:
-  python -c 'import sys; import sqlite3; sys.exit(1 if sys.version_info < (2, 7) else 0)' && pip --help > /dev/null && printf '#include "pyconfig.h"' | gcc -c -I$(python-config --includes) -xc -o /dev/null -; if [ $? -ne 0 ]; then printf "Python, the Python development packages, and pip must be installed on your system.\nUsually those packages are called python, python-devel (or python-dev) and python-pip.\n"; exit 1; fi
+  python -c 'import sys; import sqlite3; sys.exit(1 if sys.version_info < (2, 7) else 0)' && pip --help > /dev/null && printf '#include "pyconfig.h"' | gcc -c $(python-config --includes) -xc -o /dev/null -; if [ $? -ne 0 ]; then printf "Python, the Python development packages, and pip must be installed on your system.\nUsually those packages are called python, python-devel (or python-dev) and python-pip.\n"; exit 1; fi
 ---
 #!/bin/bash -ex
-
 case $ARCHITECTURE in
   slc5*) ;;
   *)
     echo "Building our own Python. If you want to avoid this please install Python >= 2.7."
   ;;
 esac
-
 rsync -av --exclude '**/.git' $SOURCEDIR/ $BUILDDIR/
-
 # The only way to pass externals to Python
 LDFLAGS=
 CPPFLAGS=
-for ext in $ALIEN_RUNTIME_ROOT $ZLIB_ROOT $FREETYPE_ROOT $LIBPNG_ROOT $SQLITE_ROOT; do
+for ext in $ALIEN_RUNTIME_ROOT $ZLIB_ROOT $FREETYPE_ROOT $LIBPNG_ROOT $SQLITE_ROOT $OPENSSL_ROOT; do
   LDFLAGS="$(find $ext -type d -name lib -exec echo -L\{\} \;) $LDFLAGS"
   CPPFLAGS="$(find $ext -type d -name include -exec echo -I\{\} \;) $CPPFLAGS"
 done
 export LDFLAGS=$(echo $LDFLAGS)
 export CPPFLAGS=$(echo $CPPFLAGS)
-
+# OpenSSL and zlib from AliEn?
+if [[ $ALIEN_RUNTIME_VERSION ]]; then
+  OPENSSL_ROOT=${OPENSSL_ROOT:+$ALIEN_RUNTIME_ROOT}
+  ZLIB_ROOT=${ZLIB_ROOT:+$ALIEN_RUNTIME_ROOT}
+fi
+# Set own OpenSSL if appropriate
+if [[ $OPENSSL_ROOT ]]; then
+  export CPATH="$OPENSSL_ROOT/include:$OPENSSL_ROOT/include/openssl:$CPATH"
+  export CPPFLAGS="-I$OPENSSL_ROOT/include -I$OPENSSL_ROOT/include/openssl $CPPFLAGS"
+  export CFLAGS="-I$OPENSSL_ROOT/include -I$OPENSSL_ROOT/include/openssl"
+  cat >> Modules/Setup.dist <<EOF
+SSL=$OPENSSL_ROOT
+_ssl _ssl.c \
+        -DUSE_SSL -I\$(SSL)/include -I\$(SSL)/include/openssl \
+        -L\$(SSL)/lib -lssl -lcrypto
+EOF
+fi
 ./configure --prefix=$INSTALLROOT \
             --enable-shared       \
             --with-system-expat   \
-            --with-system-ffi     \
             --enable-unicode=ucs4
-make ${JOBS:+-j$JOBS}
+make ${JOBS:+-j $JOBS}
 make install
-
 # Install pip
 cd $BUILDDIR
 export PATH=$INSTALLROOT/bin:$PATH
 export LD_LIBRARY_PATH=$INSTALLROOT/lib:$LD_LIBRARY_PATH
 export DYLD_LIBRARY_PATH=$INSTALLROOT/lib:$DYLD_LIBRARY_PATH
-curl -kSsL -o get-pip.py https://bootstrap.pypa.io/get-pip.py
+for U in https://bootstrap.pypa.io/get-pip.py \
+         https://raw.githubusercontent.com/pypa/get-pip/master/get-pip.py; do
+  curl -kSsL -o get-pip.py $U || continue && break
+done
 python get-pip.py
-python -m pip install -U pip
-
+python "$INSTALLROOT/bin/pip" install -U pip
+# Remove long shebangs (by default max is 128 chars on Linux)
+pushd "$INSTALLROOT/bin"
+  sed -i.deleteme -e "1 s|^#!${INSTALLROOT}/bin/\(.*\)$|#!/usr/bin/env \1|" * || true
+  rm -f *.deleteme
+popd
 # Remove useless stuff
 rm -rvf $INSTALLROOT/share \
        $INSTALLROOT/lib/python*/test
 find $INSTALLROOT/lib/python* \
      -mindepth 2 -maxdepth 2 -type d -and \( -name test -or -name tests \) \
      -exec rm -rvf '{}' \;
-
 # Execute some commands in a clean environment
 cat > $INSTALLROOT/bin/yum-cleanenv <<'EOF'
 #!/bin/bash
@@ -71,7 +88,8 @@ for F in $(echo /usr/bin/yum*) $(echo /usr/bin/rpm*); do
   [[ -e $F ]] || continue
   ln -nfs yum-cleanenv $INSTALLROOT/bin/"$(basename "$F")"
 done
-
+# Get OpenSSL and zlib at runtime from AliEn-Runtime if appropriate
+[[ $ALIEN_RUNTIME_VERSION ]] && unset OPENSSL_VERSION ZLIB_VERSION
 # Modulefile
 MODULEDIR="$INSTALLROOT/etc/modulefiles"
 MODULEFILE="$MODULEDIR/$PKGNAME"
@@ -85,8 +103,10 @@ proc ModulesHelp { } {
 set version $PKGVERSION-@@PKGREVISION@$PKGHASH@@
 module-whatis "ALICE Modulefile for $PKGNAME $PKGVERSION-@@PKGREVISION@$PKGHASH@@"
 # Dependencies
-module load BASE/1.0 $([[ $ALIEN_RUNTIME_VERSION ]] && echo "AliEn-Runtime/$ALIEN_RUNTIME_VERSION-$ALIEN_RUNTIME_REVISION" || echo "${ZLIB_VERSION:+zlib/$ZLIB_VERSION-$ZLIB_REVISION}") \\
-                     ${LIBPNG_VERSION:+libpng/$LIBPNG_VERSION-$LIBPNG_REVISION} \\
+module load BASE/1.0 ${ALIEN_RUNTIME_VERSION:+AliEn-Runtime/$ALIEN_RUNTIME_VERSION-$ALIEN_RUNTIME_REVISION} \\
+                     ${ZLIB_VERSION:+zlib/$ZLIB_VERSION-$ZLIB_REVISION}                                     \\
+                     ${OPENSSL_VERSION:+OpenSSL/$OPENSSL_VERSION-$OPENSSL_REVISION}                         \\
+                     ${LIBPNG_VERSION:+libpng/$LIBPNG_VERSION-$LIBPNG_REVISION}                             \\
                      ${FREETYPE_VERSION:+FreeType/$FREETYPE_VERSION-$FREETYPE_REVISION}
 # Our environment
 setenv PYTHON_ROOT \$::env(BASEDIR)/$PKGNAME/\$version

--- a/root.sh
+++ b/root.sh
@@ -10,6 +10,7 @@ requires:
   - FreeType:(?!osx)
   - "MySQL:slc7.*"
   - GCC-Toolchain:(?!osx)
+  - libxml2
 build_requires:
   - CMake
   - "Xcode:(osx.*)"
@@ -121,6 +122,7 @@ else
         -Dshadowpw=OFF                                            \
         -Dvdt=ON                                                  \
         -Dbuiltin_vdt=ON                                          \
+        -Dvmc=ON                                                  \
         -DCMAKE_PREFIX_PATH="$FREETYPE_ROOT;$SYS_OPENSSL_ROOT;$GSL_ROOT;$ALIEN_RUNTIME_ROOT;$PYTHON_ROOT;$PYTHON_MODULES_ROOT"
   FEATURES="builtin_pcre mathmore xml ssl opengl minuit2 http gdml ${PYTHIA_ROOT:+pythia8}
             pythia6 roofit soversion vdt ${CXX11:+cxx11} ${CXX14:+cxx14} ${XROOTD_ROOT:+xrootd}

--- a/vgm.sh
+++ b/vgm.sh
@@ -5,14 +5,18 @@ source: https://github.com/alisw/vgm.git
 requires:
   - ROOT
   - GEANT4
+  - XercesC
 build_requires:
   - CMake
 ---
 #!/bin/bash -e
 cmake "$SOURCEDIR" \
   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
-  -DCMAKE_INSTALL_LIBDIR="lib"                 \
-  -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"
+  -DCMAKE_INSTALL_LIBDIR="lib"           \
+  -DCMAKE_INSTALL_PREFIX="$INSTALLROOT"  \
+  -DWITH_EXAMPLES=OFF                \
+  -DWITH_TEST=OFF                     \
+  -DBUILD_SHARED_LIBS=OFF
 
 make ${JOBS+-j $JOBS} install
 


### PR DESCRIPTION
# The first commit's message is:

Add support for system packages for integration with CVMFS and create
2018 default version.

This PR allow simple integration with CVMFS, indeed it add for most
library a very simple system check that allow to easily use the library
installed in CVMFS.

We also create a default-fairship-2018.sh file that freeze the old
dependencies allowing to update the new thing in the 2020 branch.

# The 2nd commit message will be skipped:

#	uncomment lines wrongly commented